### PR TITLE
Replacing symbolic link by cura.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ DmgTemplateCompressed-*.dmg
 /.vscode
 /CuraEngineRepo
 /build
+.eggs

--- a/cura.py
+++ b/cura.py
@@ -1,31 +1,122 @@
 #!/usr/bin/python
+"""
+This page is in the table of contents.
+==Overview==
+===Introduction===
+Cura is a AGPL tool chain to generate a GCode path for 3D printing. Older versions of Cura where based on Skeinforge.
+Versions up from 13.05 are based on a C++ engine called CuraEngine.
+"""
+__copyright__ = "Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License"
 
-import os, sys
+from optparse import OptionParser
 
-sys.path.insert(1, os.path.dirname(__file__))
-os.environ['GDK_BACKEND'] = 'x11'
+import sys
+import os
 
-try:
-	import OpenGL
-	import wx
-	import serial
-	import numpy
-except ImportError as e:
-	print(e.message)
-	if e.message[0:16] == 'No module named ':
-		module = e.message[16:]
-
-		if module == 'OpenGL':
-			module = 'PyOpenGL'
-		elif module == 'serial':
-			module = 'pyserial'
-		print('Requires ' + module)
-		print("Try sudo easy_install " + module)
-		print(e.message)
-
-	exit(1)
+os.environ['CURABYDAGO_RELEASE_VERSION'] = '2.1.9'
+os.environ['CURABYDAGO_BUILD_VERSION'] = ''
+os.environ['CURABYDAGO_VERSION'] = os.environ['CURABYDAGO_RELEASE_VERSION'] + os.environ['CURABYDAGO_BUILD_VERSION']
 
 
-import Cura.cura as cura
+# Is it the first run after installation
+if sys.platform.startswith('darwin'):
+	try:
+		#Foundation import can crash on some MacOS installs
+		from Foundation import *
+	except:
+		pass
 
-cura.main()
+	if hasattr(sys, 'frozen'):
+		try:
+			myResourceBasePath = NSBundle.mainBundle().resourcePath()
+		except:
+			#myResourceBasePath = os.path.join(os.path.dirname(__file__), "../../../../../")
+			myResourceBasePath = os.path.dirname(__file__)
+	else:
+		myResourceBasePath = os.path.join(os.path.dirname(__file__), "../../resources")
+
+	newinstallfile = os.path.normpath(os.path.join(myResourceBasePath, 'new'))
+	if os.path.isfile(newinstallfile):
+		try:
+			os.remove(newinstallfile)
+			current_profile_inifile = os.path.expanduser('~/Library/Application Support/CuraByDagoma/' + os.environ['CURABYDAGO_VERSION'] + '/current_profile.ini')
+			if os.path.isfile(current_profile_inifile):
+				os.remove(current_profile_inifile)
+			preferences_inifile = os.path.expanduser('~/Library/Application Support/CuraByDagoma/' + os.environ['CURABYDAGO_VERSION'] + '/preferences.ini')
+			if os.path.isfile(preferences_inifile):
+				os.remove(preferences_inifile)
+		except:
+			pass
+
+from Cura.util import profile
+
+def main():
+	"""
+	Main Cura entry point. Parses arguments, and starts GUI or slicing process depending on the arguments.
+	"""
+	parser = OptionParser(usage="usage: %prog [options] <filename>.stl")
+	parser.add_option("-i", "--ini", action="store", type="string", dest="profileini",
+		help="Load settings from a profile ini file")
+	parser.add_option("-r", "--print", action="store", type="string", dest="printfile",
+		help="Open the printing interface, instead of the normal cura interface.")
+	parser.add_option("-p", "--profile", action="store", type="string", dest="profile",
+		help="Internal option, do not use!")
+	parser.add_option("-s", "--slice", action="store_true", dest="slice",
+		help="Slice the given files instead of opening them in Cura")
+	parser.add_option("-o", "--output", action="store", type="string", dest="output",
+		help="path to write sliced file to")
+	parser.add_option("--serialCommunication", action="store", type="string", dest="serialCommunication",
+		help="Start commandline serial monitor")
+
+	(options, args) = parser.parse_args()
+
+	if options.serialCommunication:
+		from Cura import serialCommunication
+		port, baud = options.serialCommunication.split(':')
+		serialCommunication.startMonitor(port, baud)
+		return
+
+	print(("Load preferences from " + profile.getPreferencePath()))
+	profile.loadPreferences(profile.getPreferencePath())
+
+	if options.profile is not None:
+		profile.setProfileFromString(options.profile)
+	elif options.profileini is not None:
+		profile.loadProfile(options.profileini)
+	else:
+		profile.loadProfile(profile.getDefaultProfilePath(), True)
+
+	if options.printfile is not None:
+		from Cura.gui import printWindow
+		printWindow.startPrintInterface(options.printfile)
+	elif options.slice is not None:
+		from Cura.util import sliceEngine
+		from Cura.util import objectScene
+		from Cura.util import meshLoader
+		import shutil
+
+		def commandlineProgressCallback(progress):
+			if progress >= 0:
+				#print 'Preparing: %d%%' % (progress * 100)
+				pass
+		scene = objectScene.Scene()
+		scene.updateMachineDimensions()
+		engine = sliceEngine.Engine(commandlineProgressCallback)
+		for m in meshLoader.loadMeshes(args[0]):
+			scene.add(m)
+		engine.runEngine(scene)
+		engine.wait()
+
+		if not options.output:
+			options.output = args[0] + profile.getGCodeExtension()
+		with open(options.output, "wb") as f:
+			f.write(engine.getResult().getGCode())
+		print(('GCode file saved : %s' % options.output))
+
+		engine.cleanup()
+	else:
+		from Cura.gui import app
+		app.CuraApp(args).MainLoop()
+
+if __name__ == '__main__':
+	main()

--- a/cura.py
+++ b/cura.py
@@ -1,1 +1,31 @@
-scripts/linux/utils/cura.py
+#!/usr/bin/python
+
+import os, sys
+
+sys.path.insert(1, os.path.dirname(__file__))
+os.environ['GDK_BACKEND'] = 'x11'
+
+try:
+	import OpenGL
+	import wx
+	import serial
+	import numpy
+except ImportError as e:
+	print(e.message)
+	if e.message[0:16] == 'No module named ':
+		module = e.message[16:]
+
+		if module == 'OpenGL':
+			module = 'PyOpenGL'
+		elif module == 'serial':
+			module = 'pyserial'
+		print('Requires ' + module)
+		print("Try sudo easy_install " + module)
+		print(e.message)
+
+	exit(1)
+
+
+import Cura.cura as cura
+
+cura.main()


### PR DESCRIPTION
Replacing the symbolic link by the file itself from scripts/linux/utils/cura.py. Necessary to debug with VS Code.