### PR TITLE
Update NSIS 2.x to NSIS 3.x

### DIFF
--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -126,7 +126,7 @@ LangString Exec_Cura ${LANG_FRENCH} "Lancer ${BUILD_NAME}"
 
 ; Reserve Files
 !insertmacro MUI_RESERVEFILE_LANGDLL
-ReserveFile '${NSISDIR}\Plugins\InstallOptions.dll'
+ReserveFile '${NSISDIR}\Plugins\x86-unicode\InstallOptions.dll'
 ReserveFile "header.bmp"
 
 Function .onInit


### PR DESCRIPTION
Fix #29 
Adapt to the new folder "x86-unicode" in nsis 3.x plugins, in installer.nsis file