### PR TITLE
Bug socket

### DIFF
--- a/Cura/util/sliceEngine.py
+++ b/Cura/util/sliceEngine.py
@@ -199,12 +199,13 @@ class Engine(object):
 		print('Listening for engine communications on %d' % (self._serverPortNr))
 		while True:
 			try:
-				sock, _ = self._serversocket.accept()
-				thread = threading.Thread(target=self._socketConnectionThread, args=(sock,))
-				thread.daemon = True
-				thread.start()
-			except OSError as e:
-				pass
+				if self._serversocket.__getattribute__('_closed') == False:
+					sock, _ = self._serversocket.accept()
+					thread = threading.Thread(target=self._socketConnectionThread, args=(sock,))
+					thread.daemon = True
+					thread.start()
+			# except OSError as e:
+			# 	pass
 			except socket.error as e:
 				if e.errno != errno.EINTR:
 					raise

--- a/Cura/util/sliceEngine.py
+++ b/Cura/util/sliceEngine.py
@@ -203,8 +203,8 @@ class Engine(object):
 				thread = threading.Thread(target=self._socketConnectionThread, args=(sock,))
 				thread.daemon = True
 				thread.start()
-			except OSError as e:
-				if self._serversocket.__getattribute__('_closed') == True:
+			except OSError as e: # to avoid error message when closing app
+				if self._serversocket.__getattribute__('_closed') == True: # check if not attempting to listen a closed socket
 					self._serversocket.close()
 					return
 				else:

--- a/Cura/util/sliceEngine.py
+++ b/Cura/util/sliceEngine.py
@@ -199,13 +199,16 @@ class Engine(object):
 		print('Listening for engine communications on %d' % (self._serverPortNr))
 		while True:
 			try:
-				if self._serversocket.__getattribute__('_closed') == False:
-					sock, _ = self._serversocket.accept()
-					thread = threading.Thread(target=self._socketConnectionThread, args=(sock,))
-					thread.daemon = True
-					thread.start()
-			# except OSError as e:
-			# 	pass
+				sock, _ = self._serversocket.accept()
+				thread = threading.Thread(target=self._socketConnectionThread, args=(sock,))
+				thread.daemon = True
+				thread.start()
+			except OSError as e:
+				if self._serversocket.__getattribute__('_closed') == True:
+					self._serversocket.close()
+					return
+				else:
+					raise
 			except socket.error as e:
 				if e.errno != errno.EINTR:
 					raise


### PR DESCRIPTION
As just check if the socket is still open before listening to it doesn't avoid the bug.
So the solution I brought consists in catching the exception and then checking it raised beacuse the socket is closed.
Fix #22 